### PR TITLE
ensure we don't block if no ethernet available

### DIFF
--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -193,7 +193,7 @@ void OXRS_Rack32::_initialiseEthernet(byte * ethernetMac)
 
   // Obtain IP address
   Serial.print(F("Getting IP address via DHCP: "));
-  if (Ethernet.begin(ethernetMac))
+  if (Ethernet.begin(ethernetMac, DHCP_TIMEOUT_MS, DHCP_RESPONSE_TIMEOUT_MS))
   {
     // Display IP address on serial
     Serial.println(Ethernet.localIP());

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -117,10 +117,14 @@ void OXRS_Rack32::begin(jsonCallback config, jsonCallback command)
 void OXRS_Rack32::loop()
 {
   // Check our ethernet connection
-  Ethernet.maintain();
-
-  // Maintain MQTT (process any messages)
-  _mqtt.loop();
+  if (Ethernet.linkStatus() == LinkON)
+  {
+    // Maintain our DHCP lease
+    Ethernet.maintain();
+    
+    // Maintain MQTT (process any messages)
+    _mqtt.loop();
+  }  
     
   // Maintain screen
   _screen.loop();
@@ -189,10 +193,16 @@ void OXRS_Rack32::_initialiseEthernet(byte * ethernetMac)
 
   // Obtain IP address
   Serial.print(F("Getting IP address via DHCP: "));
-  Ethernet.begin(ethernetMac);
-
-  // Display IP address on serial
-  Serial.println(Ethernet.localIP());
+  if (Ethernet.begin(ethernetMac))
+  {
+    // Display IP address on serial
+    Serial.println(Ethernet.localIP());
+  }
+  else
+  {
+    // Unable to obtain a DHCP lease
+    Serial.println(F("FAILED!"));
+  }
 }
 
 void OXRS_Rack32::_initialiseTempSensor()

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -10,16 +10,18 @@
 #include <OXRS_LCD.h>                 // For LCD runtime displays
 
 /* Serial */
-#define       SERIAL_BAUD_RATE        115200
+#define       SERIAL_BAUD_RATE          115200
 
 /* Ethernet */
-#define       ETHERNET_CS_PIN         26
-#define       WIZNET_RESET_PIN        13
+#define       ETHERNET_CS_PIN           26
+#define       WIZNET_RESET_PIN          13
+#define       DHCP_TIMEOUT_MS           15000
+#define       DHCP_RESPONSE_TIMEOUT_MS  4000
 
 /* MCP9808 temp sensor */
-#define       MCP9808_INTERVAL_MS     60000L
-#define       MCP9808_I2C_ADDRESS     0x18
-#define       MCP9808_MODE            0
+#define       MCP9808_INTERVAL_MS       60000
+#define       MCP9808_I2C_ADDRESS       0x18
+#define       MCP9808_MODE              0
 //  Mode Resolution  SampleTime
 //  0    0.5°C       30 ms
 //  1    0.25°C      65 ms


### PR DESCRIPTION
`Ethernet.maintain()` maintains the DHCP lease on every program loop - if you pull the ethernet cable this will block while waiting (default 60s) before timing out, thereby crippling the firmware.

Because we are using the W5500 we are able to accurately determine the link status. This change checks this status and ignores `Ethernet.maintain()` and `_mqtt.loop()` (since without ethernet we can't have an MQTT connection) if the link is down.

NOTE: If we move to supporting WiFi we would need to change this and move `_mqtt.loop()` out of this if statement.  

This means if you boot up a Rack32 with no ethernet cable, after the initial 60s timeout when trying to get a lease, the device will continue to operate in "FAILOVER" mode. This would allow local onboard processing, e.g. via my KNX shield, to continue monitoring button events and switching lights. 