### PR TITLE
add rest api server for provisioning mqtt config (and rebooting/resetting)

### DIFF
--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -503,6 +503,9 @@ void OXRS_Rack32::_initialiseMqtt(byte * mac, jsonCallback config, jsonCallback 
 
 void OXRS_Rack32::_initialiseRestApi(void)
 {
+  Serial.print(F("[api ] listening on :"));
+  Serial.println(REST_API_PORT);
+
   Serial.println(F("[api ] adding / handler [get]"));
   _api.get("/", &_getIndex);
   

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -11,13 +11,7 @@
 #include <Adafruit_MCP9808.h>         // For temp sensor
 #include <PubSubClient.h>             // For MQTT
 #include <aWOT.h>                     // For REST API
-
-#if defined(ARDUINO_ARCH_ESP32)
 #include <SPIFFS.h>                   // For ESP32 file system
-#elif defined(ARDUINO_ARCH_ESP8266)
-#include <LittleFS.h>                 // For ESP8266 file system
-#define SPIFFS LittleFS
-#endif
 
 // Filename where MQTT settings are persisted on the file system
 static const char * MQTT_JSON_FILENAME = "/mqtt.json";
@@ -45,14 +39,13 @@ const char * _fwShortName;
 const char * _fwMakerCode;
 const char * _fwVersion;
 
-// MQTT callbacks
+// MQTT callbacks wrapped by _mqttConfig/_mqttCommand
 jsonCallback _onConfig;
 jsonCallback _onCommand;
 
 /* File system helpers */
 void _mountFS()
 {
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_ESP8266)
   Serial.print(F("[file] mounting SPIFFS..."));
   if (!SPIFFS.begin())
   { 
@@ -60,12 +53,10 @@ void _mountFS()
     return; 
   }
   Serial.println(F("done"));
-#endif
 }
 
 boolean _formatFS()
 {
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_ESP8266)
   Serial.print(F("[file] formatting SPIFFS..."));
   if (!SPIFFS.format())
   { 
@@ -74,14 +65,10 @@ boolean _formatFS()
   }
   Serial.println(F("done"));
   return true;
-#else
-  return false;
-#endif
 }
 
 boolean _loadJson(DynamicJsonDocument * json, const char * filename)
 {
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_ESP8266)
   Serial.print(F("[file] reading "));  
   Serial.print(filename);
   Serial.print(F("..."));
@@ -111,14 +98,10 @@ boolean _loadJson(DynamicJsonDocument * json, const char * filename)
   }
   
   return json->isNull() ? false : true;
-#else
-  return false;
-#endif
 }
 
 boolean _saveJson(DynamicJsonDocument * json, const char * filename)
 {
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_ESP8266)
   Serial.print(F("[file] writing "));
   Serial.print(filename);
   Serial.print(F("..."));
@@ -133,14 +116,10 @@ boolean _saveJson(DynamicJsonDocument * json, const char * filename)
   Serial.print(serializeJson(*json, file));
   Serial.println(F(" bytes written"));
   return true;
-#else
-  return false;
-#endif
 }
 
 boolean _deleteFile(const char * filename)
 {
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_ESP8266)
   Serial.print(F("[file] deleting "));
   Serial.print(filename);
   Serial.print(F("..."));
@@ -153,8 +132,6 @@ boolean _deleteFile(const char * filename)
 
   Serial.println(F("done"));
   return true;
-#endif
-  return false;
 }
 
 /* REST API handlers */

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -503,9 +503,16 @@ void OXRS_Rack32::_initialiseMqtt(byte * mac, jsonCallback config, jsonCallback 
 
 void OXRS_Rack32::_initialiseRestApi(void)
 {
+  Serial.println(F("[api ] adding / handler [get]"));
   _api.get("/", &_getIndex);
+  
+  Serial.println(F("[api ] adding /reboot handler [post]"));
   _api.post("/reboot", &_postReboot);
+
+  Serial.println(F("[api ] adding /factoryReset handler [post]"));
   _api.post("/factoryReset", &_postFactoryReset);
+
+  Serial.println(F("[api ] adding /mqtt handler [post]"));
   _api.post("/mqtt", &_postMqtt);
 }
 

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -6,12 +6,18 @@
 #include "OXRS_Rack32.h"
 
 #include <Wire.h>                     // For I2C
-#include <WiFi.h>                     // Also required for Ethernet to get MAC
 #include <Ethernet.h>                 // For networking
+#include <WiFi.h>                     // Required for Ethernet to get MAC
 #include <Adafruit_MCP9808.h>         // For temp sensor
 #include <PubSubClient.h>             // For MQTT
-#include <SPIFFS.h>                   // For file system
 #include <aWOT.h>                     // For REST API
+
+#if defined(ARDUINO_ARCH_ESP32)
+#include <SPIFFS.h>                   // For ESP32 file system
+#elif defined(ARDUINO_ARCH_ESP8266)
+#include <LittleFS.h>                 // For ESP8266 file system
+#define SPIFFS LittleFS
+#endif
 
 // Filename where MQTT settings are persisted on the file system
 static const char * MQTT_SETTING_FILENAME = "/mqtt.json";

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -65,7 +65,7 @@ boolean _formatFS()
   Serial.println(F("done"));
   return true;
 #else
-  return true;
+  return false;
 #endif
 }
 
@@ -124,7 +124,7 @@ boolean _saveJson(DynamicJsonDocument * json, const char * filename)
   Serial.println(F(" bytes written"));
   return true;
 #else
-  return true;
+  return false;
 #endif
 }
 
@@ -144,7 +144,7 @@ boolean _deleteFile(const char * filename)
   Serial.println(F("done"));
   return true;
 #endif
-  return true;
+  return false;
 }
 
 /* REST API handlers */

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -252,8 +252,9 @@ void _postMqtt(Request &req, Response &res)
 /* MQTT callbacks */
 void _mqttConnected() 
 {
-  // TODO: Update screen
-
+  // Update screen
+  _screen.show_mqtt_connection_status(true);
+  
   // Build device discovery details
   DynamicJsonDocument json(512);
   
@@ -271,6 +272,12 @@ void _mqttConnected()
   
   sprintf_P(topic, PSTR("%s/%s"), _mqtt.getStatusTopic(topic), "network");
   _mqtt.publish(network, topic, true);
+}
+
+void _mqttDisconnected() 
+{
+  // Update screen
+  _screen.show_mqtt_connection_status(false);
 }
 
 void _mqttCallback(char * topic, byte * payload, int length) 
@@ -383,7 +390,7 @@ void OXRS_Rack32::loop()
       _api.process(&client);
       client.stop();
     }    
-  }  
+  }
     
   // Maintain screen
   _screen.loop();
@@ -480,6 +487,7 @@ void OXRS_Rack32::_initialiseMqtt(byte * mac, jsonCallback config, jsonCallback 
 
   // Register our callbacks
   _mqtt.onConnected(_mqttConnected);
+  _mqtt.onDisconnected(_mqttDisconnected);
   _mqtt.onConfig(config);
   _mqtt.onCommand(command);
 

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -5,9 +5,9 @@
 #ifndef OXRS_RACK32_H
 #define OXRS_RACK32_H
 
-#include <ArduinoJson.h>
 #include <OXRS_MQTT.h>                // For MQTT
 #include <OXRS_LCD.h>                 // For LCD runtime displays
+#include <ArduinoJson.h>
 
 /* Serial */
 #define       SERIAL_BAUD_RATE          115200
@@ -17,6 +17,8 @@
 #define       WIZNET_RESET_PIN          13
 #define       DHCP_TIMEOUT_MS           15000
 #define       DHCP_RESPONSE_TIMEOUT_MS  4000
+
+#define       REST_API_PORT             8080
 
 /* MCP9808 temp sensor */
 #define       MCP9808_INTERVAL_MS       60000

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -9,10 +9,10 @@
 #include <OXRS_LCD.h>                 // For LCD runtime displays
 #include <ArduinoJson.h>
 
-/* Serial */
+// Serial
 #define       SERIAL_BAUD_RATE          115200
 
-/* Ethernet */
+// Ethernet
 #define       ETHERNET_CS_PIN           26
 #define       WIZNET_RESET_PIN          13
 #define       DHCP_TIMEOUT_MS           15000
@@ -20,7 +20,7 @@
 
 #define       REST_API_PORT             8080
 
-/* MCP9808 temp sensor */
+// MCP9808 temp sensor
 #define       MCP9808_INTERVAL_MS       60000
 #define       MCP9808_I2C_ADDRESS       0x18
 #define       MCP9808_MODE              0
@@ -62,12 +62,13 @@ class OXRS_Rack32
     jsonCallback _onConfig;
     jsonCallback _onCommand;
 
-    void _initialiseEthernet(byte * ethernetMac);
-
+    void _initialiseEthernet();
+    void _initialiseMqtt(jsonCallback config, jsonCallback command);
+    void _initialiseRestApi(void);
+    
     void _initialiseTempSensor(void);
     void _updateTempSensor(void);
-    
-    uint32_t _lastTempUpdate = -MCP9808_INTERVAL_MS;
+    uint32_t _lastTempUpdate;
 };
 
 #endif

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -52,7 +52,7 @@ class OXRS_Rack32
 
   private:
     void _initialiseEthernet(byte * mac);
-    void _initialiseMqtt(byte * mac, jsonCallback config, jsonCallback command);
+    void _initialiseMqtt(byte * mac);
     void _initialiseRestApi(void);
     
     void _initialiseTempSensor(void);

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -51,10 +51,6 @@ class OXRS_Rack32
     boolean publishTelemetry(JsonObject json);
 
   private:
-    voidCallback _onConnected;
-    jsonCallback _onConfig;
-    jsonCallback _onCommand;
-
     void _initialiseEthernet(byte * mac);
     void _initialiseMqtt(byte * mac, jsonCallback config, jsonCallback command);
     void _initialiseRestApi(void);

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -5,7 +5,7 @@
 #ifndef OXRS_RACK32_H
 #define OXRS_RACK32_H
 
-#include <OXRS_MQTT.h>                // For MQTT
+#include <OXRS_MQTT.h>                // For MQTT pub/sub
 #include <OXRS_LCD.h>                 // For LCD runtime displays
 #include <ArduinoJson.h>
 
@@ -18,6 +18,7 @@
 #define       DHCP_TIMEOUT_MS           15000
 #define       DHCP_RESPONSE_TIMEOUT_MS  4000
 
+// REST API
 #define       REST_API_PORT             8080
 
 // MCP9808 temp sensor
@@ -57,6 +58,7 @@ class OXRS_Rack32
     
     void _initialiseTempSensor(void);
     void _updateTempSensor(void);
+    
     uint32_t _lastTempUpdate = -MCP9808_INTERVAL_MS;
 };
 

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -36,9 +36,10 @@ typedef void (*jsonCallback)(JsonObject);
 class OXRS_Rack32
 {
   public:
-    OXRS_Rack32(const char * fwName, const char * fwShortName, const char * fwMakerCode, const char * fwVersion, const char * fwCode);
+    OXRS_Rack32(const char * fwName, const char * fwShortName, const char * fwMakerCode, const char * fwVersion);
     
     void setMqttBroker(const char * broker, uint16_t port);
+    void setMqttClientId(const char * clientId);
     void setMqttAuth(const char * username, const char * password);
     void setMqttTopicPrefix(const char * prefix);
     void setMqttTopicSuffix(const char * suffix);
@@ -53,12 +54,6 @@ class OXRS_Rack32
     boolean publishTelemetry(JsonObject json);
 
   private:
-    const char * _fwName;
-    const char * _fwShortName;
-    const char * _fwMakerCode;
-    const char * _fwVersion;
-    const char * _fwCode;
-    
     jsonCallback _onConfig;
     jsonCallback _onCommand;
 

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -30,17 +30,14 @@
 //  2    0.125°C     130 ms
 //  3    0.0625°C    250 ms
 
-// Callback type for onConfig() and onCommand()
-typedef void (*jsonCallback)(JsonObject);
-
 class OXRS_Rack32
 {
   public:
     OXRS_Rack32(const char * fwName, const char * fwShortName, const char * fwMakerCode, const char * fwVersion);
-    
+   
     void setMqttBroker(const char * broker, uint16_t port);
-    void setMqttClientId(const char * clientId);
     void setMqttAuth(const char * username, const char * password);
+    void setMqttClientId(const char * clientId);
     void setMqttTopicPrefix(const char * prefix);
     void setMqttTopicSuffix(const char * suffix);
 
@@ -54,16 +51,17 @@ class OXRS_Rack32
     boolean publishTelemetry(JsonObject json);
 
   private:
+    voidCallback _onConnected;
     jsonCallback _onConfig;
     jsonCallback _onCommand;
 
-    void _initialiseEthernet();
-    void _initialiseMqtt(jsonCallback config, jsonCallback command);
+    void _initialiseEthernet(byte * mac);
+    void _initialiseMqtt(byte * mac, jsonCallback config, jsonCallback command);
     void _initialiseRestApi(void);
     
     void _initialiseTempSensor(void);
     void _updateTempSensor(void);
-    uint32_t _lastTempUpdate;
+    uint32_t _lastTempUpdate = -MCP9808_INTERVAL_MS;
 };
 
 #endif

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -64,7 +64,7 @@ class OXRS_Rack32
 
     void _initialiseEthernet(byte * ethernetMac);
 
-    void _initialiseTempSensor(void);    
+    void _initialiseTempSensor(void);
     void _updateTempSensor(void);
     
     uint32_t _lastTempUpdate = -MCP9808_INTERVAL_MS;


### PR DESCRIPTION
Relates to https://github.com/OXRS-IO/OXRS-IO-MQTT-ESP32-LIB/pull/11

I am using Postman to test, but there are 3 REST API endpoints available with this change;

```
/mqtt [GET or POST] - get or set MQTT setup config
/reboot [POST] - soft restart the ESP32
/factoryReset [POST] - wipe any MQTT persisted setup/config data from SPIFFS and reboot
```

NOTE: you can optionally pass a json payload to `/factoryReset` -> `{ "formatFileSystem": true }` which will cause a full SPIFFS format. Thought this might be useful for when a device is brand new and hasn't been formatted yet? By default it will only wipe the setup/config files - i.e. no format.

So now we can remove `config.h` altogether and our firmware is completely custom config free. Once the device is connected to the network you can provision your MQTT connection details via `/mqtt` and clear them via `/factoryReset`.

Have a look and see what you think. We can build an Admin UI on top of this relatively easily now.