### PR TITLE
Device config

### DIFF
--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -40,7 +40,7 @@ const char * _fwMakerCode;
 const char * _fwVersion;
 
 // Supported device config
-DynamicJsonDocument _deviceConfig(2048);
+DynamicJsonDocument _deviceConfig(4096);
 
 // MQTT callbacks wrapped by _mqttConfig/_mqttCommand
 jsonCallback _onConfig;
@@ -200,7 +200,7 @@ void _getIndex(Request &req, Response &res)
 {
   Serial.println(F("[api ] index"));
 
-  DynamicJsonDocument json(512);
+  DynamicJsonDocument json(4096);
   
   JsonObject firmware = json.createNestedObject("firmware");
   _getFirmwareJson(&firmware);
@@ -287,7 +287,7 @@ void _mqttConnected()
   _screen.show_mqtt_connection_status(true);
   
   // Build device adoption info
-  DynamicJsonDocument json(512);
+  DynamicJsonDocument json(4096);
   
   JsonObject firmware = json.createNestedObject("firmware");
   _getFirmwareJson(&firmware);

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -40,12 +40,15 @@ class OXRS_Rack32
 {
   public:
     OXRS_Rack32(const char * fwName, const char * fwShortName, const char * fwMakerCode, const char * fwVersion);
-   
+       
     void setMqttBroker(const char * broker, uint16_t port);
     void setMqttAuth(const char * username, const char * password);
     void setMqttClientId(const char * clientId);
     void setMqttTopicPrefix(const char * prefix);
     void setMqttTopicSuffix(const char * suffix);
+
+    // Firmware can define what config options it supports - for device discovery and adoption
+    void setDeviceConfig(JsonObject json);
 
     void setDisplayPorts(uint8_t mcp23017s, int layout);
     void updateDisplayPorts(uint8_t mcp23017, uint16_t ioValue);


### PR DESCRIPTION
Add the ability for the firmware to supply a set of config (in JSON) which is published to the `stat/<deviceid>/adopt` topic (retained) for device discovery.