### PR TITLE
shorten LCD event display (to fit larger type/event names)

### DIFF
--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -409,7 +409,7 @@ boolean OXRS_Rack32::publishStatus(JsonVariant json)
   if (json.containsKey("index"))
   {
     char event[32];
-    sprintf_P(event, PSTR("id:%2d"), json["index"].as<uint8_t>());
+    sprintf_P(event, PSTR("%2d:"), json["index"].as<uint8_t>());
 
     if (json.containsKey("type") && json.containsKey("event"))
     {

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -409,7 +409,7 @@ boolean OXRS_Rack32::publishStatus(JsonVariant json)
   if (json.containsKey("index"))
   {
     char event[32];
-    sprintf_P(event, PSTR("%2d:"), json["index"].as<uint8_t>());
+    sprintf_P(event, PSTR("[%2d]"), json["index"].as<uint8_t>());
 
     if (json.containsKey("type") && json.containsKey("event"))
     {

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -409,7 +409,7 @@ boolean OXRS_Rack32::publishStatus(JsonVariant json)
   if (json.containsKey("index"))
   {
     char event[32];
-    sprintf_P(event, PSTR("idx:%2d"), json["index"].as<uint8_t>());
+    sprintf_P(event, PSTR("id:%2d"), json["index"].as<uint8_t>());
 
     if (json.containsKey("type") && json.containsKey("event"))
     {

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -408,8 +408,9 @@ boolean OXRS_Rack32::publishStatus(JsonVariant json)
   // Check for something we can show on the screen
   if (json.containsKey("index"))
   {
+    // Pad the index to 3 chars - to ensure a consistent display for all indices
     char event[32];
-    sprintf_P(event, PSTR("[%2d]"), json["index"].as<uint8_t>());
+    sprintf_P(event, PSTR("[%3d]"), json["index"].as<uint8_t>());
 
     if (json.containsKey("type") && json.containsKey("event"))
     {


### PR DESCRIPTION
Having trouble with the new `security` events, in particular `normal` and `tamper` - they are not quite fitting on the screen.

We might need to try something different;

`[132] security tamper`
`132: security tamper`

Open to other suggestions...