### PR TITLE
add explicit .getLCD() method instead of returning in .begin().

### DIFF
--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -334,32 +334,7 @@ void OXRS_Rack32::setMqttTopicSuffix(const char * suffix)
   _mqtt.setTopicSuffix(suffix);
 }
 
-void OXRS_Rack32::setConfigSchema(JsonVariant json)
-{
-  _mergeJson(_fwConfigSchema.as<JsonVariant>(), json);
-}
-
-void OXRS_Rack32::setCommandSchema(JsonVariant json)
-{
-  _mergeJson(_fwCommandSchema.as<JsonVariant>(), json);
-}
-
-void OXRS_Rack32::setDisplayPortLayout(uint8_t mcpCount, int layout)
-{
-  _screen.draw_ports(layout, mcpCount);
-}
-
-void OXRS_Rack32::setDisplayPortConfig(uint8_t mcp, uint8_t pin, int config)
-{
-  _screen.setPortConfig(mcp, pin, config);
-}
-
-void OXRS_Rack32::updateDisplayPorts(uint8_t mcp, uint16_t ioValue)
-{
-  _screen.process(mcp, ioValue);
-}
-
-OXRS_LCD* OXRS_Rack32::begin(jsonCallback config, jsonCallback command)
+void OXRS_Rack32::begin(jsonCallback config, jsonCallback command)
 {
   // We wrap the callbacks so we can intercept messages intended for the Rack32
   _onConfig = config;
@@ -380,9 +355,6 @@ OXRS_LCD* OXRS_Rack32::begin(jsonCallback config, jsonCallback command)
 
   // Set up the temperature sensor
   _initialiseTempSensor();
-  
-  // return pointer to the LCD_LIB
-  return &_screen;
 }
 
 void OXRS_Rack32::loop(void)
@@ -406,6 +378,36 @@ void OXRS_Rack32::loop(void)
 
   // Check for temperature update
   _updateTempSensor();
+}
+
+void OXRS_Rack32::setConfigSchema(JsonVariant json)
+{
+  _mergeJson(_fwConfigSchema.as<JsonVariant>(), json);
+}
+
+void OXRS_Rack32::setCommandSchema(JsonVariant json)
+{
+  _mergeJson(_fwCommandSchema.as<JsonVariant>(), json);
+}
+
+OXRS_LCD* OXRS_Rack32::getLCD()
+{
+  return &_screen;
+}
+
+void OXRS_Rack32::setDisplayPortLayout(uint8_t mcpCount, int layout)
+{
+  _screen.draw_ports(layout, mcpCount);
+}
+
+void OXRS_Rack32::setDisplayPortConfig(uint8_t mcp, uint8_t pin, int config)
+{
+  _screen.setPortConfig(mcp, pin, config);
+}
+
+void OXRS_Rack32::updateDisplayPorts(uint8_t mcp, uint16_t ioValue)
+{
+  _screen.process(mcp, ioValue);
 }
 
 boolean OXRS_Rack32::publishStatus(JsonVariant json)

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -48,17 +48,23 @@ class OXRS_Rack32
     void setMqttTopicPrefix(const char * prefix);
     void setMqttTopicSuffix(const char * suffix);
 
+    void begin(jsonCallback config, jsonCallback command);
+    void loop(void);
+
     // Firmware can define the config/commands it supports - for device discovery and adoption
     void setConfigSchema(JsonVariant json);
     void setCommandSchema(JsonVariant json);
 
+    // Return a pointer to the LCD so firmware can customise if required
+    // Should be called after .begin()
+    OXRS_LCD* getLCD(void);
+
+    // Helpers for standard I/O setup of the LCD
     void setDisplayPortLayout(uint8_t mcpCount, int layout);
     void setDisplayPortConfig(uint8_t mcp, uint8_t pin, int config);
     void updateDisplayPorts(uint8_t mcp, uint16_t ioValue);
-    
-    OXRS_LCD* begin(jsonCallback config, jsonCallback command);
-    void loop(void);
-
+        
+    // Helpers for publishing to stat/ and tele/ topics
     boolean publishStatus(JsonVariant json);
     boolean publishTelemetry(JsonVariant json);
 


### PR DESCRIPTION
Apologies for the large change set - I re-ordered some of the functions to be more logical in terms of how they should be used - i.e. screen shouldn't be accessed or configured until after `.begin()` has been called.

The only functional change is add `.getLCD()` and not returning it in `.begin()`.