### PR TITLE
implement mqtt logging for remote debugging

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-SHA-Rack32-ESP32-LIB
-version=1.7.0
+version=1.8.0
 author=SuperHouse Automation Pty Ltd
 maintainer=Ben Jones <ben.jones@gmail.com>
 sentence=ESP32 Rack32 library for Open eXtensible Rack System firmware
@@ -7,4 +7,4 @@ paragraph=
 category=Signal Input/Output
 url=https://github.com/SuperHouse/OXRS-SHA-Rack32-ESP32-LIB
 architectures=*
-depends=Adafruit MCP9808 Library,ArduinoJson,PubSubClient,OXRS-IO-API-ESP32-LIB,OXRS-IO-MQTT-ESP32-LIB,OXRS-IO-LCD-ESP32-LIB
+depends=Adafruit MCP9808 Library,ArduinoJson,PubSubClient,MqttLogger,OXRS-IO-API-ESP32-LIB,OXRS-IO-MQTT-ESP32-LIB,OXRS-IO-LCD-ESP32-LIB

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -8,9 +8,8 @@
 #include <Wire.h>                     // For I2C
 #include <Ethernet.h>                 // For networking
 #include <WiFi.h>                     // Required for Ethernet to get MAC
-#include <Adafruit_MCP9808.h>         // For temp sensor
-#include <PubSubClient.h>             // For MQTT
 #include <MqttLogger.h>               // For logging
+#include <Adafruit_MCP9808.h>         // For temp sensor
 
 // Ethernet client
 EthernetClient _client;
@@ -481,7 +480,7 @@ boolean OXRS_Rack32::publishTelemetry(JsonVariant json)
 
 size_t OXRS_Rack32::write(uint8_t character)
 {
-  // Pass thru to MQTT logger
+  // Pass to logger - allows firmware to use `rack32.println("Log this!")`
   return _logger.write(character);
 }
 

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -241,7 +241,6 @@ void _mqttConfig(JsonVariant json)
       // wipes recent temp display on screen
       _screen.hideTemp();
     }
-
   }
   
   // LCD config
@@ -291,16 +290,16 @@ void _mqttCallback(char * topic, byte * payload, int length)
   switch (state)
   {
     case MQTT_RECEIVE_ZERO_LENGTH:
-      Serial.println(F("[ra32] empty mqtt payload received"));
+      _mqtt.println(F("[ra32] empty mqtt payload received"));
       break;
     case MQTT_RECEIVE_JSON_ERROR:
-      Serial.println(F("[ra32] failed to deserialise mqtt json payload"));
+      _mqtt.println(F("[ra32] failed to deserialise mqtt json payload"));
       break;
     case MQTT_RECEIVE_NO_CONFIG_HANDLER:
-      Serial.println(F("[ra32] no mqtt config handler"));
+      _mqtt.println(F("[ra32] no mqtt config handler"));
       break;
     case MQTT_RECEIVE_NO_COMMAND_HANDLER:
-      Serial.println(F("[ra32] no mqtt command handler"));
+      _mqtt.println(F("[ra32] no mqtt command handler"));
       break;
   }
 }
@@ -469,6 +468,12 @@ boolean OXRS_Rack32::publishTelemetry(JsonVariant json)
   boolean success = _mqtt.publishTelemetry(json);
   if (success) { _screen.triggerMqttTxLed(); }
   return success;
+}
+
+size_t OXRS_Rack32::write(uint8_t character)
+{
+  // Pass thru to MQTT logger
+  return _mqtt.write(character);
 }
 
 void OXRS_Rack32::_initialiseScreen(void)

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -30,7 +30,7 @@
 //  2    0.125°C     130 ms
 //  3    0.0625°C    250 ms
 
-class OXRS_Rack32
+class OXRS_Rack32 : public Print
 {
   public:
     OXRS_Rack32(
@@ -68,6 +68,10 @@ class OXRS_Rack32
     // Helpers for publishing to stat/ and tele/ topics
     boolean publishStatus(JsonVariant json);
     boolean publishTelemetry(JsonVariant json);
+
+    // Implement Print.h wrapper
+    virtual size_t write(uint8_t);
+    using Print::write;
 
   private:
     void _initialiseScreen(void);


### PR DESCRIPTION
This change allows the caller to write log messages directly using the Rack32 library; 

```
// log simple text
rack32.print("log this!!");
rack32.println();

// log a JSON object
serializeJson(json, rack32);
```