### PR TITLE
changes to support platformio

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-SHA-Rack32-ESP32-LIB
-version=1.9.0
+version=2.0.0
 author=SuperHouse Automation Pty Ltd
 maintainer=Ben Jones <ben.jones@gmail.com>
 sentence=ESP32 Rack32 library for Open eXtensible Rack System firmware

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -33,12 +33,7 @@
 class OXRS_Rack32 : public Print
 {
   public:
-    OXRS_Rack32(
-      const char * fwName, 
-      const char * fwShortName, 
-      const char * fwMaker, 
-      const char * fwVersion, 
-      const uint8_t * fwLogo = NULL);
+    OXRS_Rack32(const uint8_t * fwLogo = NULL);
 
     // These are only needed if performing manual configuration in your sketch, otherwise
     // config is provisioned via the API and bootstrap page


### PR DESCRIPTION
Move to using env vars for the firmware name/version metadata. This makes it easier to define these in PlatformIO and pass around, rather than having to edit them in the firmware source code.

Allows us to automatically tag builds as `DEBUG` when developing/testing. And only tag them with a proper version when cutting a release.

Also moved the code to dump the firmware details into the Rack32 lib, so the main firmware code doesn't ever need to know about these variables.

The beauty of PlatformIO is we can leave these changes in a branch and slowly migrate the other OXRS repos over, by simply pointing them at this branch of the Rack32 library, while the remaining can still work against the `main` branch as per usual.