### PR TITLE
remove restart command (supported directly via API lib)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-SHA-Rack32-ESP32-LIB
-version=2.3.0
+version=2.4.0
 author=SuperHouse Automation Pty Ltd
 maintainer=Ben Jones <ben.jones@gmail.com>
 sentence=ESP32 Rack32 library for Open eXtensible Rack System firmware

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -225,11 +225,6 @@ void _getCommandSchemaJson(JsonVariant json)
   {
     _mergeJson(properties, _fwCommandSchema.as<JsonVariant>());
   }
-
-  // Rack32 commands
-  JsonObject restart = properties.createNestedObject("restart");
-  restart["title"] = "Restart";
-  restart["type"] = "boolean";
 }
 
 /* API callbacks */
@@ -335,12 +330,6 @@ void _mqttConfig(JsonVariant json)
 
 void _mqttCommand(JsonVariant json)
 {
-  // Check for library commands
-  if (json.containsKey("restart") && json["restart"].as<bool>())
-  {
-    ESP.restart();
-  }
-  
   // Pass on to the firmware callback
   if (_onCommand) { _onCommand(json); }
 }
@@ -464,11 +453,13 @@ void OXRS_Rack32::loop(void)
 
 void OXRS_Rack32::setConfigSchema(JsonVariant json)
 {
+  _fwConfigSchema.clear();
   _mergeJson(_fwConfigSchema.as<JsonVariant>(), json);
 }
 
 void OXRS_Rack32::setCommandSchema(JsonVariant json)
 {
+  _fwCommandSchema.clear();
   _mergeJson(_fwCommandSchema.as<JsonVariant>(), json);
 }
 


### PR DESCRIPTION
Also ensure config/command JSON schemas are cleared when `setXxxSchema()` is called.