### PR TITLE
increase json document sizes

### DIFF
--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -52,8 +52,8 @@ Adafruit_MCP9808 _tempSensor;
 const uint8_t * _fwLogo;
  
 // Supported firmware config and command schemas
-DynamicJsonDocument _fwConfigSchema(2048);
-DynamicJsonDocument _fwCommandSchema(2048);
+DynamicJsonDocument _fwConfigSchema(4096);
+DynamicJsonDocument _fwCommandSchema(4096);
 
 // MQTT callbacks wrapped by _mqttConfig/_mqttCommand
 jsonCallback _onConfig;
@@ -378,7 +378,7 @@ void OXRS_Rack32::setMqttTopicSuffix(const char * suffix)
 void OXRS_Rack32::begin(jsonCallback config, jsonCallback command)
 {
   // Get our firmware details
-  DynamicJsonDocument json(128);
+  DynamicJsonDocument json(512);
   _getFirmwareJson(json.as<JsonVariant>());
 
   // Log firmware details


### PR DESCRIPTION
I noticed the PDU command schema was bigger than 2048 now that I have added verbose descriptions to various fields. 