### PR TITLE
add 5m timeout to captive portal

### DIFF
--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -611,9 +611,16 @@ void OXRS_Rack32::_initialiseNetwork(byte * mac)
   // Ensure we are in the correct WiFi mode
   WiFi.mode(WIFI_STA);
 
-  // Connect using saved creds, or start captive portal if none found
-  // NOTE: Blocks until connected or the portal is closed
+  // We use WifiManager library from https://github.com/tzapu/WiFiManager
+  // to handle WiFi connection and credential persistence etc.
   WiFiManager wm;
+
+  // If the captive portal is launched and nothing happens for a while then
+  // continue - this helps if we come online before an AP (e.g. power outage)
+  // and prevents us sitting in captive portal mode indefinitely
+  wm.setConfigPortalTimeout(WM_CONFIG_PORTAL_TIMEOUT_S);
+
+  // Connect using saved creds, or start captive portal if none found
   bool success = wm.autoConnect("OXRS_WiFi", "superhouse");
 
   _logger.print(F("[ra32] ip address: "));

--- a/src/OXRS_Rack32.cpp
+++ b/src/OXRS_Rack32.cpp
@@ -616,15 +616,20 @@ void OXRS_Rack32::_initialiseNetwork(byte * mac)
   WiFiManager wm;
 
   // If the captive portal is launched and nothing happens for a while then
-  // continue - this helps if we come online before an AP (e.g. power outage)
+  // reboot - this helps if we come online before an AP (e.g. power outage)
   // and prevents us sitting in captive portal mode indefinitely
   wm.setConfigPortalTimeout(WM_CONFIG_PORTAL_TIMEOUT_S);
 
   // Connect using saved creds, or start captive portal if none found
-  bool success = wm.autoConnect("OXRS_WiFi", "superhouse");
+  // NOTE: Blocks until connected or the portal is closed
+  if (!wm.autoConnect("OXRS_WiFi", "superhouse"))
+  {
+    _logger.println(F("[ra32] failed to connect to wifi access point, rebooting"));
+    ESP.restart();
+  }
 
   _logger.print(F("[ra32] ip address: "));
-  _logger.println(success ? WiFi.localIP() : IPAddress(0, 0, 0, 0));
+  _logger.println(WiFi.localIP());
 #else
   _logger.print(F("[ra32] ethernet mac address: "));
   _logger.println(mac_display);

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -9,25 +9,28 @@
 #include <OXRS_API.h>                 // For REST API
 #include <OXRS_LCD.h>                 // For LCD runtime displays
 
+// WifiManager
+#define       WM_CONFIG_PORTAL_TIMEOUT_S  300
+
 // Ethernet
-#define       ETHERNET_CS_PIN           26
-#define       WIZNET_RESET_PIN          13
-#define       DHCP_TIMEOUT_MS           15000
-#define       DHCP_RESPONSE_TIMEOUT_MS  4000
+#define       ETHERNET_CS_PIN             26
+#define       WIZNET_RESET_PIN            13
+#define       DHCP_TIMEOUT_MS             15000
+#define       DHCP_RESPONSE_TIMEOUT_MS    4000
 
 // I2C
-#define       I2C_SDA                   21
-#define       I2C_SCL                   22
+#define       I2C_SDA                     21
+#define       I2C_SCL                     22
 
 // REST API
-#define       REST_API_PORT             80
+#define       REST_API_PORT               80
 
 // Temperature update internal
-#define       DEFAULT_TEMP_UPDATE_MS    60000L
+#define       DEFAULT_TEMP_UPDATE_MS      60000L
 
 // MCP9808 temperature sensor
-#define       MCP9808_I2C_ADDRESS       0x18
-#define       MCP9808_MODE              0
+#define       MCP9808_I2C_ADDRESS         0x18
+#define       MCP9808_MODE                0
 //  Mode Resolution  SampleTime
 //  0    0.5°C       30 ms
 //  1    0.25°C      65 ms


### PR DESCRIPTION
This prevents a device which is rebooting when there is no WiFi available, from sitting in captive portal mode indefinitely.

The Rack32 needs to continue booting and allow processing of events in failover mode if the network or MQTT is down.

Ideally we would periodically try to reconnect to WiFi once the captive portal expires, if there are WiFi creds saved, but I am not sure how easy this is to do with the WifiManager lib.