### PR TITLE
add new OXRS_LCD_ENABLE flag to simplify firmware code

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-SHA-Rack32-ESP32-LIB
-version=2.8.0
+version=2.9.0
 author=SuperHouse Automation Pty Ltd
 maintainer=Ben Jones <ben.jones@gmail.com>
 sentence=ESP32 Rack32 library for Open eXtensible Rack System firmware

--- a/src/OXRS_Rack32.h
+++ b/src/OXRS_Rack32.h
@@ -9,6 +9,9 @@
 #include <OXRS_API.h>                 // For REST API
 #include <OXRS_LCD.h>                 // For LCD runtime displays
 
+// LCD screen
+#define       OXRS_LCD_ENABLE
+
 // WifiManager
 #define       WM_CONFIG_PORTAL_TIMEOUT_S  300
 


### PR DESCRIPTION
Use this in firmware code to determine whether to initialise and use the LCD - saves having to have multiple checks;

`#if defined(OXRS_RACK32) or defined(OXRS_BLACK)`